### PR TITLE
Fix distortion factor in ROS CameraInfo

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -157,9 +157,9 @@ sensor_msgs::CameraInfo convertToCameraInfo(OBCameraIntrinsic intrinsic,
   info.D.resize(5, 0.0);
   info.D[0] = distortion.k1;
   info.D[1] = distortion.k2;
-  info.D[2] = distortion.k3;
-  info.D[3] = distortion.k4;
-  info.D[4] = distortion.k5;
+  info.D[2] = distortion.p1;
+  info.D[3] = distortion.p2;
+  info.D[4] = distortion.k3;
 
   info.K.fill(0.0);
   info.K[0] = intrinsic.fx;


### PR DESCRIPTION
According to the message definition for [`sensor_msgs/CameraInfo`](http://docs.ros.org/en/api/sensor_msgs/html/msg/CameraInfo.html):

```yaml
# The distortion parameters, size depending on the distortion model.
# For "plumb_bob", the 5 parameters are: (k1, k2, t1, t2, k3).
float64[] D
```

However, this package currently populates it as follows
https://github.com/orbbec/OrbbecSDK_ROS1/blob/09325b1f6fbc533e19969c6eacd76420938b33d0/src/utils.cpp#L158-L162

This PR corrects the population of this portion of the message to be consistent with the message definition