### PR TITLE
Setup CameraInfoManager

### DIFF
--- a/include/orbbec_camera/ob_camera_node.h
+++ b/include/orbbec_camera/ob_camera_node.h
@@ -256,6 +256,8 @@ class OBCameraNode {
  private:
   ros::NodeHandle nh_;
   ros::NodeHandle nh_private_;
+  ros::NodeHandle nh_rgb_;
+  ros::NodeHandle nh_ir_;
   std::shared_ptr<ob::Device> device_ = nullptr;
   std::shared_ptr<ob::DeviceInfo> device_info_ = nullptr;
   std::atomic_bool is_running_{false};

--- a/src/ob_camera_node.cpp
+++ b/src/ob_camera_node.cpp
@@ -34,6 +34,8 @@ OBCameraNode::OBCameraNode(ros::NodeHandle& nh, ros::NodeHandle& nh_private,
   stream_name_[INFRA1] = "ir2";
   stream_name_[ACCEL] = "accel";
   stream_name_[GYRO] = "gyro";
+  nh_ir_ = ros::NodeHandle(stream_name_[INFRA0]);
+  nh_rgb_ = ros::NodeHandle(stream_name_[COLOR]);
   init();
 }
 
@@ -854,7 +856,20 @@ void OBCameraNode::onNewFrameCallback(const std::shared_ptr<ob::Frame>& frame,
   }
   std::string frame_id =
       depth_registration_ ? depth_aligned_frame_id_[stream_index] : optical_frame_id_[stream_index];
-  if (camera_params_) {
+  if (color_camera_info_->isCalibrated() && stream_index == COLOR) {
+    auto camera_info_publisher = camera_info_publishers_[stream_index];
+    auto camera_info = color_camera_info_->getCameraInfo();
+    camera_info.header.stamp = timestamp;
+    camera_info.header.frame_id = frame_id;
+    camera_info_publisher.publish(camera_info);
+  } else if (ir_camera_info_->isCalibrated() &&
+             (stream_index == INFRA0 || stream_index == DEPTH)) {
+    auto camera_info_publisher = camera_info_publishers_[stream_index];
+    auto camera_info = ir_camera_info_->getCameraInfo();
+    camera_info.header.stamp = timestamp;
+    camera_info.header.frame_id = frame_id;
+    camera_info_publisher.publish(camera_info);
+  } else if (camera_params_) {
     auto& intrinsic =
         stream_index == COLOR ? camera_params_->rgbIntrinsic : camera_params_->depthIntrinsic;
     auto& distortion =

--- a/src/ros_setup.cpp
+++ b/src/ros_setup.cpp
@@ -275,6 +275,10 @@ void OBCameraNode::setupPublishers() {
 }
 
 void OBCameraNode::setupCameraInfo() {
+  color_camera_info_ = std::make_shared<camera_info_manager::CameraInfoManager>(
+      nh_rgb_, camera_name_ + "_" + stream_name_[COLOR], color_info_uri_);
+  ir_camera_info_ = std::make_shared<camera_info_manager::CameraInfoManager>(
+      nh_ir_, camera_name_ + "_" + stream_name_[INFRA0], ir_info_uri_);
   auto param = getCameraParam();
   if (param) {
     camera_infos_[DEPTH] = convertToCameraInfo(param->depthIntrinsic, param->depthDistortion,


### PR DESCRIPTION
Setup CameraInfoManager.
If camera info is setup from file or service, publish camera_info based on the values from CameraInfoManager.

- fix #14 