### PR TITLE
Add EXECUTABLES to install macro, re issue #22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,7 @@ macro(add_orbbec_executable TARGET SOURCES)
   add_executable(${TARGET} ${SOURCES})
   target_link_libraries(${TARGET} ${COMMON_LINK_LIBRARIES} ${PROJECT_NAME})
   target_include_directories(${TARGET} PUBLIC ${COMMON_INCLUDE_DIRS})
+  list(APPEND EXECUTABLES ${TARGET})
 endmacro()
 
 # Add nodes


### PR DESCRIPTION
I've added cmake code to append to the EXECUTABLES list in the add_obbec_executable macro. As discussed previously on issue #22 it appears that the intention was to grow the EXECUTABLES list in the macro to simplify the install directive on line 231.

I have tested this change on my setupo with colcon and I find it works well.
