### PR TITLE
Add missing fstream include

### DIFF
--- a/src/ob_camera_node.cpp
+++ b/src/ob_camera_node.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  *******************************************************************************/
 
+#include <fstream>
+
 #include "orbbec_camera/ob_camera_node.h"
 #include "libobsensor/hpp/Utils.hpp"
 #if defined(USE_RK_HW_DECODER)


### PR DESCRIPTION
This file makes use of [std::ofstream](https://github.com/orbbec/OrbbecSDK_ROS1/blob/de9b846ccc4a94f276a9b8a08774500719830470/src/ob_camera_node.cpp#L1460), but does not include the fstream header.

Inclusion avoids the following error:

```sh
/ws/src/orbbec/OrbbecSDK/src/ob_camera_node.cpp:1654:25: error: variable ‘std::ofstream ofs’ has initializer but incomplete type
 1654 |       std::ofstream ofs(filename, std::ios::out | std::ios::binary);
```