### PR TITLE
Only create SW filter if align_mode is set to SW

### DIFF
--- a/src/ros_setup.cpp
+++ b/src/ros_setup.cpp
@@ -1279,7 +1279,7 @@ void OBCameraNode::setupProfiles() {
       ROS_ERROR_STREAM("set d2c error " << e.getMessage());
     }
   }
-  if (depth_registration_ || align_mode_ == "SW") {
+  if (depth_registration_ && align_mode_ == "SW") {
     align_filter_ = std::make_shared<ob::Align>(align_target_stream_);
   }
 }


### PR DESCRIPTION
The current code creates a software filter if _depth_registration_ is set to true regardless of whether _align_mode_ is set to HW or SW. This fix makes sure that the sw filter is created only when both conditions are met