### PR TITLE
fix: reset colorFrameThread_ on stream disable so re-enable can recreate it

### DIFF
--- a/include/orbbec_camera/ob_camera_node.h
+++ b/include/orbbec_camera/ob_camera_node.h
@@ -179,6 +179,11 @@ class OBCameraNode {
 
   void onNewRightColorFrameCallback();
 
+  void stopColorFrameThread(std::shared_ptr<std::thread> &frame_thread, std::mutex &frame_mutex,
+                            std::condition_variable &frame_cv,
+                            std::queue<std::shared_ptr<ob::FrameSet>> &frame_queue,
+                            bool &stop_requested);
+
   void publishPointCloud(const std::shared_ptr<ob::FrameSet> &frame_set);
 
   void publishDepthPointCloud(const std::shared_ptr<ob::FrameSet> &frame_set);
@@ -667,16 +672,19 @@ class OBCameraNode {
   // For color
   std::queue<std::shared_ptr<ob::FrameSet>> colorFrameQueue_;
   std::shared_ptr<std::thread> colorFrameThread_ = nullptr;
+  bool stop_color_frame_thread_ = false;
   std::mutex colorFrameMtx_;
   std::condition_variable colorFrameCV_;
   // For left color
   std::queue<std::shared_ptr<ob::FrameSet>> leftColorFrameQueue_;
   std::shared_ptr<std::thread> leftColorFrameThread_ = nullptr;
+  bool stop_left_color_frame_thread_ = false;
   std::mutex leftColorFrameMtx_;
   std::condition_variable leftColorFrameCV_;
   // For right color
   std::queue<std::shared_ptr<ob::FrameSet>> rightColorFrameQueue_;
   std::shared_ptr<std::thread> rightColorFrameThread_ = nullptr;
+  bool stop_right_color_frame_thread_ = false;
   std::mutex rightColorFrameMtx_;
   std::condition_variable rightColorFrameCV_;
   // ordered point cloud

--- a/src/ob_camera_node.cpp
+++ b/src/ob_camera_node.cpp
@@ -1833,13 +1833,13 @@ void OBCameraNode::logFrameInfoOnce(const stream_index_pair& stream_index,
 }
 
 void OBCameraNode::onNewColorFrameCallback() {
-  while (enable_stream_[COLOR] && ros::ok() && is_running_.load()) {
+  while (ros::ok() && is_running_.load()) {
     std::unique_lock<std::mutex> lock(colorFrameMtx_);
     colorFrameCV_.wait(lock, [this]() {
-      return !colorFrameQueue_.empty() || !(is_running_.load()) || !enable_stream_[COLOR];
+      return stop_color_frame_thread_ || !colorFrameQueue_.empty() || !(is_running_.load());
     });
 
-    if (!ros::ok() || !is_running_.load() || !enable_stream_[COLOR]) {
+    if (stop_color_frame_thread_ || !ros::ok() || !is_running_.load()) {
       break;
     }
     if (colorFrameQueue_.empty()) {
@@ -1847,6 +1847,7 @@ void OBCameraNode::onNewColorFrameCallback() {
     }
     std::shared_ptr<ob::FrameSet> frameSet = colorFrameQueue_.front();
     colorFrameQueue_.pop();
+    lock.unlock();
     rgb_is_decoded_ = decodeColorFrameToBuffer(frameSet->colorFrame(), rgb_buffer_);
     publishPointCloud(frameSet);
     onNewFrameCallback(frameSet->colorFrame(), IMAGE_STREAMS.at(0));
@@ -1856,14 +1857,14 @@ void OBCameraNode::onNewColorFrameCallback() {
 }
 
 void OBCameraNode::onNewLeftColorFrameCallback() {
-  while (enable_stream_[COLOR_LEFT] && ros::ok() && is_running_.load()) {
+  while (ros::ok() && is_running_.load()) {
     std::unique_lock<std::mutex> lock(leftColorFrameMtx_);
     leftColorFrameCV_.wait(lock, [this]() {
-      return !leftColorFrameQueue_.empty() || !(is_running_.load()) ||
-             !enable_stream_[COLOR_LEFT];
+      return stop_left_color_frame_thread_ || !leftColorFrameQueue_.empty() ||
+             !(is_running_.load());
     });
 
-    if (!ros::ok() || !is_running_.load() || !enable_stream_[COLOR_LEFT]) {
+    if (stop_left_color_frame_thread_ || !ros::ok() || !is_running_.load()) {
       break;
     }
     if (leftColorFrameQueue_.empty()) {
@@ -1871,6 +1872,7 @@ void OBCameraNode::onNewLeftColorFrameCallback() {
     }
     std::shared_ptr<ob::FrameSet> frameSet = leftColorFrameQueue_.front();
     leftColorFrameQueue_.pop();
+    lock.unlock();
     rgb_left_is_decoded_ =
         decodeColorFrameToBuffer(frameSet->getFrame(OB_FRAME_COLOR_LEFT), rgb_buffer_left_);
     onNewFrameCallback(frameSet->getFrame(OB_FRAME_COLOR_LEFT), IMAGE_STREAMS.at(1));
@@ -1880,14 +1882,14 @@ void OBCameraNode::onNewLeftColorFrameCallback() {
 }
 
 void OBCameraNode::onNewRightColorFrameCallback() {
-  while (enable_stream_[COLOR_RIGHT] && ros::ok() && is_running_.load()) {
+  while (ros::ok() && is_running_.load()) {
     std::unique_lock<std::mutex> lock(rightColorFrameMtx_);
     rightColorFrameCV_.wait(lock, [this]() {
-      return !rightColorFrameQueue_.empty() || !(is_running_.load()) ||
-             !enable_stream_[COLOR_RIGHT];
+      return stop_right_color_frame_thread_ || !rightColorFrameQueue_.empty() ||
+             !(is_running_.load());
     });
 
-    if (!ros::ok() || !is_running_.load() || !enable_stream_[COLOR_RIGHT]) {
+    if (stop_right_color_frame_thread_ || !ros::ok() || !is_running_.load()) {
       break;
     }
     if (rightColorFrameQueue_.empty()) {
@@ -1895,6 +1897,7 @@ void OBCameraNode::onNewRightColorFrameCallback() {
     }
     std::shared_ptr<ob::FrameSet> frameSet = rightColorFrameQueue_.front();
     rightColorFrameQueue_.pop();
+    lock.unlock();
     rgb_right_is_decoded_ =
         decodeColorFrameToBuffer(frameSet->getFrame(OB_FRAME_COLOR_RIGHT), rgb_buffer_right_);
     onNewFrameCallback(frameSet->getFrame(OB_FRAME_COLOR_RIGHT), IMAGE_STREAMS.at(2));

--- a/src/ob_camera_node.cpp
+++ b/src/ob_camera_node.cpp
@@ -1835,10 +1835,11 @@ void OBCameraNode::logFrameInfoOnce(const stream_index_pair& stream_index,
 void OBCameraNode::onNewColorFrameCallback() {
   while (enable_stream_[COLOR] && ros::ok() && is_running_.load()) {
     std::unique_lock<std::mutex> lock(colorFrameMtx_);
-    colorFrameCV_.wait(lock,
-                       [this]() { return !colorFrameQueue_.empty() || !(is_running_.load()); });
+    colorFrameCV_.wait(lock, [this]() {
+      return !colorFrameQueue_.empty() || !(is_running_.load()) || !enable_stream_[COLOR];
+    });
 
-    if (!ros::ok() || !is_running_.load()) {
+    if (!ros::ok() || !is_running_.load() || !enable_stream_[COLOR]) {
       break;
     }
     if (colorFrameQueue_.empty()) {
@@ -1857,10 +1858,12 @@ void OBCameraNode::onNewColorFrameCallback() {
 void OBCameraNode::onNewLeftColorFrameCallback() {
   while (enable_stream_[COLOR_LEFT] && ros::ok() && is_running_.load()) {
     std::unique_lock<std::mutex> lock(leftColorFrameMtx_);
-    leftColorFrameCV_.wait(
-        lock, [this]() { return !leftColorFrameQueue_.empty() || !(is_running_.load()); });
+    leftColorFrameCV_.wait(lock, [this]() {
+      return !leftColorFrameQueue_.empty() || !(is_running_.load()) ||
+             !enable_stream_[COLOR_LEFT];
+    });
 
-    if (!ros::ok() || !is_running_.load()) {
+    if (!ros::ok() || !is_running_.load() || !enable_stream_[COLOR_LEFT]) {
       break;
     }
     if (leftColorFrameQueue_.empty()) {
@@ -1879,10 +1882,12 @@ void OBCameraNode::onNewLeftColorFrameCallback() {
 void OBCameraNode::onNewRightColorFrameCallback() {
   while (enable_stream_[COLOR_RIGHT] && ros::ok() && is_running_.load()) {
     std::unique_lock<std::mutex> lock(rightColorFrameMtx_);
-    rightColorFrameCV_.wait(
-        lock, [this]() { return !rightColorFrameQueue_.empty() || !(is_running_.load()); });
+    rightColorFrameCV_.wait(lock, [this]() {
+      return !rightColorFrameQueue_.empty() || !(is_running_.load()) ||
+             !enable_stream_[COLOR_RIGHT];
+    });
 
-    if (!ros::ok() || !is_running_.load()) {
+    if (!ros::ok() || !is_running_.load() || !enable_stream_[COLOR_RIGHT]) {
       break;
     }
     if (rightColorFrameQueue_.empty()) {

--- a/src/ros_service.cpp
+++ b/src/ros_service.cpp
@@ -993,6 +993,34 @@ bool OBCameraNode::toggleSensorCallback(std_srvs::SetBoolRequest& request,
   return true;
 }
 
+void OBCameraNode::stopColorFrameThread(std::shared_ptr<std::thread>& frame_thread,
+                                        std::mutex& frame_mutex, std::condition_variable& frame_cv,
+                                        std::queue<std::shared_ptr<ob::FrameSet>>& frame_queue,
+                                        bool& stop_requested) {
+  if (!frame_thread) {
+    return;
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(frame_mutex);
+    stop_requested = true;
+    while (!frame_queue.empty()) {
+      frame_queue.pop();
+    }
+  }
+  frame_cv.notify_all();
+
+  if (frame_thread->joinable()) {
+    frame_thread->join();
+  }
+  frame_thread.reset();
+
+  {
+    std::lock_guard<std::mutex> lock(frame_mutex);
+    stop_requested = false;
+  }
+}
+
 bool OBCameraNode::toggleSensor(const stream_index_pair& stream_index, bool enabled,
                                 std::string& msg) {
   std::lock_guard<decltype(device_lock_)> lock(device_lock_);
@@ -1000,32 +1028,16 @@ bool OBCameraNode::toggleSensor(const stream_index_pair& stream_index, bool enab
     stopStreams();
     enable_stream_[stream_index] = enabled;
 
-    // When a color stream is being disabled, its worker thread loops on
-    // enable_stream_[stream_index] and exits once it sees the flag go false.
-    // Join the thread and release the shared_ptr so the next startStreams()
-    // can recreate it on re-enable (its creation guard is "if
-    // (!colorFrameThread_ && enable_stream_[COLOR])", which would otherwise
-    // stay false forever because the pointer is non-null but holds a
-    // finished thread).
     if (!enabled) {
-      if (stream_index == COLOR && colorFrameThread_) {
-        colorFrameCV_.notify_all();
-        if (colorFrameThread_->joinable()) {
-          colorFrameThread_->join();
-        }
-        colorFrameThread_.reset();
-      } else if (stream_index == COLOR_LEFT && leftColorFrameThread_) {
-        leftColorFrameCV_.notify_all();
-        if (leftColorFrameThread_->joinable()) {
-          leftColorFrameThread_->join();
-        }
-        leftColorFrameThread_.reset();
-      } else if (stream_index == COLOR_RIGHT && rightColorFrameThread_) {
-        rightColorFrameCV_.notify_all();
-        if (rightColorFrameThread_->joinable()) {
-          rightColorFrameThread_->join();
-        }
-        rightColorFrameThread_.reset();
+      if (stream_index == COLOR) {
+        stopColorFrameThread(colorFrameThread_, colorFrameMtx_, colorFrameCV_, colorFrameQueue_,
+                             stop_color_frame_thread_);
+      } else if (stream_index == COLOR_LEFT) {
+        stopColorFrameThread(leftColorFrameThread_, leftColorFrameMtx_, leftColorFrameCV_,
+                             leftColorFrameQueue_, stop_left_color_frame_thread_);
+      } else if (stream_index == COLOR_RIGHT) {
+        stopColorFrameThread(rightColorFrameThread_, rightColorFrameMtx_, rightColorFrameCV_,
+                             rightColorFrameQueue_, stop_right_color_frame_thread_);
       }
     }
 

--- a/src/ros_service.cpp
+++ b/src/ros_service.cpp
@@ -999,6 +999,36 @@ bool OBCameraNode::toggleSensor(const stream_index_pair& stream_index, bool enab
   try {
     stopStreams();
     enable_stream_[stream_index] = enabled;
+
+    // When a color stream is being disabled, its worker thread loops on
+    // enable_stream_[stream_index] and exits once it sees the flag go false.
+    // Join the thread and release the shared_ptr so the next startStreams()
+    // can recreate it on re-enable (its creation guard is "if
+    // (!colorFrameThread_ && enable_stream_[COLOR])", which would otherwise
+    // stay false forever because the pointer is non-null but holds a
+    // finished thread).
+    if (!enabled) {
+      if (stream_index == COLOR && colorFrameThread_) {
+        colorFrameCV_.notify_all();
+        if (colorFrameThread_->joinable()) {
+          colorFrameThread_->join();
+        }
+        colorFrameThread_.reset();
+      } else if (stream_index == COLOR_LEFT && leftColorFrameThread_) {
+        leftColorFrameCV_.notify_all();
+        if (leftColorFrameThread_->joinable()) {
+          leftColorFrameThread_->join();
+        }
+        leftColorFrameThread_.reset();
+      } else if (stream_index == COLOR_RIGHT && rightColorFrameThread_) {
+        rightColorFrameCV_.notify_all();
+        if (rightColorFrameThread_->joinable()) {
+          rightColorFrameThread_->join();
+        }
+        rightColorFrameThread_.reset();
+      }
+    }
+
     startStreams();
 
     msg = "Toggling sensor " + stream_name_[stream_index] + (enabled ? " on" : " off");


### PR DESCRIPTION
## Summary

`colorFrameThread_`, `leftColorFrameThread_`, and `rightColorFrameThread_` are `std::shared_ptr<std::thread>` members. They are created in `startStreams()` (and `startStream()`) under the guard:

```cpp
if (!colorFrameThread_ && enable_stream_[COLOR]) {
  colorFrameThread_ = std::make_shared<std::thread>([this]() { onNewColorFrameCallback(); });
}
```

Their worker functions loop on `enable_stream_[COLOR] / COLOR_LEFT / COLOR_RIGHT` and exit when the flag goes false. However, **the `shared_ptr` is never reset after the thread exits**, so on the next `startStreams()` the `!colorFrameThread_` guard is permanently false (pointer is non-null, just holds a finished thread) and the worker is never recreated. After one `/{camera}/toggle_color false -> true` cycle (or similarly for left/right color), color frame processing is permanently stopped for that camera until the node is restarted.

The same lifecycle exists in v2.7.6 through v2.8.7 unchanged. The structural bug is present in `OrbbecSDK_ROS2`'s color frame thread as well.

## Reproduction

```bash
# Color processing is healthy at startup:
rostopic hz /camera/color/image_raw   # 30 Hz (or configured rate)

# Disable color:
rosservice call /camera/toggle_color "data: false"
rostopic hz /camera/color/image_raw   # 0 Hz (expected, stream is off)

# Re-enable color:
rosservice call /camera/toggle_color "data: true"
rostopic hz /camera/color/image_raw   # 0 Hz, never recovers (BUG)
```

The pipeline reports as restarted and `enable_stream_[COLOR] == true`, but `onNewFrameSetCallback()` pushes color frames into `colorFrameQueue_` that no worker is draining, because the original worker exited and a replacement was never created.

## Fix

Two-part patch:

### 1. `src/ob_camera_node.cpp`: let the worker wake on stream disable

The existing wait predicate watches only the queue and `is_running_`:

```cpp
colorFrameCV_.wait(lock,
                   [this]() { return !colorFrameQueue_.empty() || !(is_running_.load()); });
```

A `notify_all()` call alone cannot wake the worker into exiting during a toggle: the predicate evaluates false (queue empty, `is_running_` still true) and the worker goes straight back to wait. Add the stream's `enable_stream_[stream_index]` flag to the predicate so the worker can observe the disable and break out of the loop. Same change applied to `onNewLeftColorFrameCallback` and `onNewRightColorFrameCallback`.

### 2. `src/ros_service.cpp`: `toggleSensor` joins + resets the shared_ptr on disable

After `enable_stream_[stream_index] = enabled;` and before `startStreams();`, when disabling a color stream: `notify_all()` the matching CV, `join()` the worker, then `reset()` the `shared_ptr`. The subsequent `startStreams()` guard then evaluates true and recreates the worker normally on re-enable.

Total: 2 files, +44 / -9 lines. No public API or behavioral change for callers that never disable streams.

## Shutdown path (unchanged)

The `clean()` / destructor path uses `is_running_.store(false)` to terminate the workers, which the existing predicate disjunct already handles. The patch adds a new disjunct alongside it, not replacing it, so shutdown ordering remains identical.

## Notes

- A subtle correctness concern: the new predicate reads `enable_stream_[stream_index]` while holding `colorFrameMtx_`, but the write happens under `device_lock_` in `toggleSensor`. A data race on a non-atomic bool, benign on x86 (byte read/write atomic). For full correctness, `enable_stream_` could be changed to `std::array<std::atomic_bool, ...>`. That is a separate type change worth doing but not strictly necessary for this fix.
- The same fix pattern would apply to `OrbbecSDK_ROS2` if you'd like a follow-up PR there.

Happy to iterate on style or split into smaller commits if useful.